### PR TITLE
Fix access levels for importing as CocoaPod

### DIFF
--- a/Sources/Client.swift
+++ b/Sources/Client.swift
@@ -39,7 +39,7 @@ public enum CentrifugeClientStatus {
 public class CentrifugeClient {
     var conn: WebSocket?
     var token: String?
-    public var client: String?
+    var client: String?
     var commandId: UInt32 = 0
     var commandIdLock: NSLock = NSLock()
     var url: String

--- a/Sources/Client.swift
+++ b/Sources/Client.swift
@@ -26,6 +26,8 @@ public struct CentrifugeClientConfig {
     var maxReconnectDelay = 20.0
     var privateChannelPrefix = "$"
     var pingInterval = 25.0
+
+    public init() {}
 }
 
 public enum CentrifugeClientStatus {
@@ -37,7 +39,7 @@ public enum CentrifugeClientStatus {
 public class CentrifugeClient {
     var conn: WebSocket?
     var token: String?
-    var client: String?
+    public var client: String?
     var commandId: UInt32 = 0
     var commandIdLock: NSLock = NSLock()
     var url: String
@@ -58,7 +60,7 @@ public class CentrifugeClient {
     var syncQueue: DispatchQueue
     var connecting = false
 
-    init(url: String, config: CentrifugeClientConfig, delegate: CentrifugeClientDelegate, delegateQueue: OperationQueue? = nil) {
+    public init(url: String, config: CentrifugeClientConfig, delegate: CentrifugeClientDelegate, delegateQueue: OperationQueue? = nil) {
         self.url = url
         
         // iOS client work only over Protobuf protocol.

--- a/Sources/Delegate.swift
+++ b/Sources/Delegate.swift
@@ -9,53 +9,53 @@
 import Foundation
 
 public struct CentrifugeConnectEvent{
-    var client: String
+    public var client: String
 }
 
 public struct CentrifugeDisconnectEvent{
-    var reason: String
-    var reconnect: Bool
+    public var reason: String
+    public var reconnect: Bool
 }
 
 public struct CentrifugeRefreshEvent{}
 
 public struct CentrifugeJoinEvent {
-    var client: String
-    var user: String
-    var connInfo: Data
-    var chanInfo: Data
+    public var client: String
+    public var user: String
+    public var connInfo: Data
+    public var chanInfo: Data
 }
 
 public struct CentrifugeLeaveEvent {
-    var client: String
-    var user: String
-    var connInfo: Data
-    var chanInfo: Data
+    public var client: String
+    public var user: String
+    public var connInfo: Data
+    public var chanInfo: Data
 }
 
 public struct CentrifugeMessageEvent {
-    var data: Data
+    public var data: Data
 }
 
 public struct CentrifugePublishEvent {
-    var uid: String
-    var data: Data
+    public var uid: String
+    public var data: Data
     var info: Proto_ClientInfo?
 }
 
 public struct CentrifugePrivateSubEvent {
-    var client: String
-    var channel: String
+    public var client: String
+    public var channel: String
 }
 
 public struct CentrifugeSubscribeErrorEvent {
-    var code: UInt32
-    var message: String
+    public var code: UInt32
+    public var message: String
 }
 
 public struct CentrifugeSubscribeSuccessEvent {
-    var resubscribe = false
-    var recovered = false
+    public var resubscribe = false
+    public var recovered = false
 }
 
 public struct CentrifugeUnsubscribeEvent {}


### PR DESCRIPTION
Update the access level for some methods and properties implicitly marked as `internal` when Centrifugo is imported as a module (via CocoaPods)