### PR TITLE
Mark Client delegate as `weak` and make it optional

### DIFF
--- a/Sources/Client.swift
+++ b/Sources/Client.swift
@@ -35,6 +35,8 @@ public enum CentrifugeClientStatus {
 }
 
 public class CentrifugeClient {
+    public weak var delegate: CentrifugeClientDelegate?
+
     var conn: WebSocket?
     var token: String?
     var client: String?
@@ -52,13 +54,12 @@ public class CentrifugeClient {
     var pingTimer: DispatchSourceTimer?
     var disconnectOpts: disconnectOptions?
     var refreshTask: DispatchWorkItem?
-    var delegate: CentrifugeClientDelegate
     var workQueue: DispatchQueue
     var delegateQueue: OperationQueue
     var syncQueue: DispatchQueue
     var connecting = false
 
-    init(url: String, config: CentrifugeClientConfig, delegate: CentrifugeClientDelegate, delegateQueue: OperationQueue? = nil) {
+    init(url: String, config: CentrifugeClientConfig, delegate: CentrifugeClientDelegate? = nil, delegateQueue: OperationQueue? = nil) {
         self.url = url
         
         // iOS client work only over Protobuf protocol.
@@ -92,7 +93,7 @@ public class CentrifugeClient {
         guard let client = self.client else { completion(""); return }
         self.delegateQueue.addOperation { [weak self] in
             guard let strongSelf = self else { return }
-            strongSelf.delegate.onPrivateSub(
+            strongSelf.delegate?.onPrivateSub(
                 strongSelf,
                 CentrifugePrivateSubEvent(client: client, channel: channel)
             ) {[weak self] token in
@@ -270,7 +271,7 @@ public class CentrifugeClient {
         } else if push.type == Proto_PushType.message {
             let message = try Proto_Message(serializedData: push.data)
             self.delegateQueue.addOperation {
-                self.delegate.onMessage(self, CentrifugeMessageEvent(data: message.data))
+                self.delegate?.onMessage(self, CentrifugeMessageEvent(data: message.data))
             }
         }
     }
@@ -354,7 +355,7 @@ public class CentrifugeClient {
     func startConnectionRefresh(ttl: UInt32) {
         let refreshTask = DispatchWorkItem {
             self.delegateQueue.addOperation {
-                self.delegate.onRefresh(self, CentrifugeRefreshEvent()) {[weak self] token in
+                self.delegate?.onRefresh(self, CentrifugeRefreshEvent()) {[weak self] token in
                     guard let strongSelf = self else { return }
                     if token == "" {
                         return
@@ -397,7 +398,7 @@ public class CentrifugeClient {
                         strongSelf.client = result.client
                         strongSelf.delegateQueue.addOperation { [weak self] in
                             guard let strongSelf = self else { return }
-                            strongSelf.delegate.onConnect(strongSelf, CentrifugeConnectEvent(client: result.client))
+                            strongSelf.delegate?.onConnect(strongSelf, CentrifugeConnectEvent(client: result.client))
                         }
                         for (_, cb) in strongSelf.connectCallbacks {
                             cb(nil)
@@ -412,7 +413,7 @@ public class CentrifugeClient {
                         if code == 109 {
                             strongSelf.delegateQueue.addOperation { [weak self] in
                                 guard let strongSelf = self else { return }
-                                strongSelf.delegate.onRefresh(strongSelf, CentrifugeRefreshEvent()) {[weak self] token in
+                                strongSelf.delegate?.onRefresh(strongSelf, CentrifugeRefreshEvent()) {[weak self] token in
                                     guard let strongSelf = self else { return }
                                     if token != "" {
                                         strongSelf.token = token
@@ -486,7 +487,7 @@ public class CentrifugeClient {
         if previousStatus == .new || previousStatus == .connected  {
             self.delegateQueue.addOperation { [weak self] in
                 guard let strongSelf = self else { return }
-                strongSelf.delegate.onDisconnect(
+                strongSelf.delegate?.onDisconnect(
                     strongSelf,
                     CentrifugeDisconnectEvent(reason: reason, reconnect: reconnect)
                 )

--- a/Sources/Delegate.swift
+++ b/Sources/Delegate.swift
@@ -60,7 +60,7 @@ public struct CentrifugeSubscribeSuccessEvent {
 
 public struct CentrifugeUnsubscribeEvent {}
 
-public protocol CentrifugeClientDelegate {
+public protocol CentrifugeClientDelegate: class {
     func onConnect(_ c: CentrifugeClient, _ e: CentrifugeConnectEvent)
     func onDisconnect(_ c: CentrifugeClient, _ e: CentrifugeDisconnectEvent)
     func onPrivateSub(_ c: CentrifugeClient, _ e: CentrifugePrivateSubEvent, completion: (_ token: String) -> ())


### PR DESCRIPTION
Mark Client delegate as `weak` to match "delegate" pattern best practices and avoid probable retain cycles between Client and its Delegate (which would lead to a memory leak).

Having `delegate` parameter on the init method as an optional type helps to instantiate the Client itself as a non-optional property inside some other class init method, in case this class wants to be the delegate. Otherwise we could not pass `self` as a delegate diuring `init` process.