### PR TITLE
Mark `refresh` and `private sub` completion blocks as escaping

### DIFF
--- a/Sources/SwiftCentrifuge/Delegate.swift
+++ b/Sources/SwiftCentrifuge/Delegate.swift
@@ -63,18 +63,18 @@ public struct CentrifugeUnsubscribeEvent {}
 public protocol CentrifugeClientDelegate: class {
     func onConnect(_ client: CentrifugeClient, _ event: CentrifugeConnectEvent)
     func onDisconnect(_ client: CentrifugeClient, _ event: CentrifugeDisconnectEvent)
-    func onPrivateSub(_ client: CentrifugeClient, _ event: CentrifugePrivateSubEvent, completion: (_ token: String) -> ())
-    func onRefresh(_ client: CentrifugeClient, _ event: CentrifugeRefreshEvent, completion: (_ token: String) -> ())
+    func onPrivateSub(_ client: CentrifugeClient, _ event: CentrifugePrivateSubEvent, completion: @escaping (_ token: String) -> ())
+    func onRefresh(_ client: CentrifugeClient, _ event: CentrifugeRefreshEvent, completion: @escaping (_ token: String) -> ())
     func onMessage(_ client: CentrifugeClient, _ event: CentrifugeMessageEvent)
 }
 
 public extension CentrifugeClientDelegate {
     func onConnect(_ client: CentrifugeClient, _ event: CentrifugeConnectEvent) {}
     func onDisconnect(_ client: CentrifugeClient, _ event: CentrifugeDisconnectEvent) {}
-    func onPrivateSub(_ client: CentrifugeClient, _ event: CentrifugePrivateSubEvent, completion: (_ token: String) -> ()) {
+    func onPrivateSub(_ client: CentrifugeClient, _ event: CentrifugePrivateSubEvent, completion: @escaping (_ token: String) -> ()) {
         completion("")
     }
-    func onRefresh(_ client: CentrifugeClient, _ event: CentrifugeRefreshEvent, completion: (_ token: String) -> ()) {
+    func onRefresh(_ client: CentrifugeClient, _ event: CentrifugeRefreshEvent, completion: @escaping (_ token: String) -> ()) {
         completion("")
     }
     func onMessage(_ client: CentrifugeClient, _ event: CentrifugeMessageEvent) {}

--- a/SwiftCentrifuge.podspec
+++ b/SwiftCentrifuge.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
     s.source                = { :git => 'https://github.com/centrifugal/centrifuge-swift.git', :tag => s.version }
 
     s.dependency 'SwiftProtobuf'
-    s.dependency 'Starscream'
+    s.dependency 'Starscream', '~> 3'
 end


### PR DESCRIPTION
Having these blocks marked as `escaping` is essential if the `CentrifugeClientDelegate` implementation calls them not "inline" but asynchronously, which is the case for most real-life situations.

In our case the delegate makes an async call to REST authorization service to provide fresh tokens:

```swift
func onRefresh(_ client: CentrifugeClient, _ event: CentrifugeRefreshEvent,
	completion: @escaping (_ token: String) -> Void) {

	DDLogInfo("Centrifuge requested to refresh the token...", level: logLevel)

	self.requestCredentials(for: .user) { (credential) in
		completion(credential.token)
	}
}
```

As `requestCredentials` method is async and escapes it's completion block, the completion of `onRefresh` escapes as well.