### PR TITLE
Implement fetching and removing existing subscriptions

### DIFF
--- a/Sources/SwiftCentrifuge/Client.swift
+++ b/Sources/SwiftCentrifuge/Client.swift
@@ -233,6 +233,34 @@ public class CentrifugeClient {
         self.subscriptions.append(sub)
         return sub
     }
+
+    /**
+     Try to get Subscription from internal client registry. Can return nil if Subscription
+     does not exist yet.
+     - parameter channel: String
+     - returns: CentrifugeSubscription?
+     */
+    public func getSubscription(channel: String) -> CentrifugeSubscription? {
+        defer { subscriptionsLock.unlock() }
+        subscriptionsLock.lock()
+        return self.subscriptions.first(where: { $0.channel == channel })
+    }
+
+    /**
+     * Say Client that Subscription should be removed from internal registry. Subscription will be
+     * automatically unsubscribed before removing.
+     - parameter channel: String
+     */
+    public func removeSubscription(channel: String) {
+        defer { subscriptionsLock.unlock() }
+        subscriptionsLock.lock()
+        self.subscriptions
+            .filter({ $0.channel == channel })
+            .forEach { (sub) in
+                sub.unsubscribe()
+            }
+        self.subscriptions.removeAll(where: { $0.channel == channel })
+    }
 }
 
 internal extension CentrifugeClient {

--- a/Sources/SwiftCentrifuge/Client.swift
+++ b/Sources/SwiftCentrifuge/Client.swift
@@ -249,17 +249,17 @@ public class CentrifugeClient {
     /**
      * Say Client that Subscription should be removed from internal registry. Subscription will be
      * automatically unsubscribed before removing.
-     - parameter channel: String
+     - parameter sub: CentrifugeSubscription
      */
-    public func removeSubscription(channel: String) {
+    public func removeSubscription(_ sub: CentrifugeSubscription) {
         defer { subscriptionsLock.unlock() }
         subscriptionsLock.lock()
         self.subscriptions
-            .filter({ $0.channel == channel })
-            .forEach { (sub) in
+            .filter({ $0.channel == sub.channel })
+            .forEach { sub in
                 sub.unsubscribe()
             }
-        self.subscriptions.removeAll(where: { $0.channel == channel })
+        self.subscriptions.removeAll(where: { $0.channel == sub.channel })
     }
 }
 


### PR DESCRIPTION
This PR adds `getSubscription` and `removeSubscription` methods to the Client.


I read #18 and understand that it is a debatable issue - whether the library should support removing subscriptions.
But since the Android library already have these operations it would be reasonable to add them to the swift one as well.


Our project depends on this behavior, we have some short living channel subscriptions it makes no sense to store the subscriptions forever.

Refs https://github.com/centrifugal/centrifuge-swift/issues/18.