### PR TITLE
Fix refresh token task retain cycle

### DIFF
--- a/Sources/SwiftCentrifuge/Client.swift
+++ b/Sources/SwiftCentrifuge/Client.swift
@@ -652,10 +652,10 @@ fileprivate extension CentrifugeClient {
     }
     
     private func startConnectionRefresh(ttl: UInt32) {
-		let refreshTask = DispatchWorkItem { [weak self] in
-			self?.delegateQueue.addOperation {
-				guard let strongSelf = self else { return }
-				strongSelf.delegate?.onRefresh(strongSelf, CentrifugeRefreshEvent()) { [weak self] token in
+        let refreshTask = DispatchWorkItem { [weak self] in
+            self?.delegateQueue.addOperation {
+                guard let strongSelf = self else { return }
+                strongSelf.delegate?.onRefresh(strongSelf, CentrifugeRefreshEvent()) { [weak self] token in
                     guard let strongSelf = self else { return }
                     if token == "" {
                         return

--- a/Sources/SwiftCentrifuge/Client.swift
+++ b/Sources/SwiftCentrifuge/Client.swift
@@ -652,9 +652,10 @@ fileprivate extension CentrifugeClient {
     }
     
     private func startConnectionRefresh(ttl: UInt32) {
-        let refreshTask = DispatchWorkItem {
-            self.delegateQueue.addOperation {
-                self.delegate?.onRefresh(self, CentrifugeRefreshEvent()) {[weak self] token in
+		let refreshTask = DispatchWorkItem { [weak self] in
+			self?.delegateQueue.addOperation {
+				guard let strongSelf = self else { return }
+				strongSelf.delegate?.onRefresh(strongSelf, CentrifugeRefreshEvent()) { [weak self] token in
                     guard let strongSelf = self else { return }
                     if token == "" {
                         return


### PR DESCRIPTION
Fix the refresh token task retain cycle. The client leaked right after a successful connect.