### PR TITLE
Subprotocol to avoid URL param

### DIFF
--- a/Sources/SwiftCentrifuge/Client.swift
+++ b/Sources/SwiftCentrifuge/Client.swift
@@ -193,7 +193,7 @@ public class CentrifugeClient {
             for (key, value) in strongSelf.config.headers {
                 request.addValue(value, forHTTPHeaderField: key)
             }
-            let ws = WebSocket(request: request)
+            let ws = WebSocket(request: request, protocols: ["centrifuge-protobuf"])
             if strongSelf.config.tlsSkipVerify {
                 ws.disableSSLCertValidation = true
             }


### PR DESCRIPTION
This will allow omit `?format=protobuf` when working with Centrifugo v3 and Centrifuge >= v0.18.0