### PR TITLE
Make the delegate public so it can be set.

### DIFF
--- a/Sources/SwiftCentrifuge/Subscription.swift
+++ b/Sources/SwiftCentrifuge/Subscription.swift
@@ -28,7 +28,7 @@ public class CentrifugeSubscription {
     private var needRecover: Bool = false
     private var lastEpoch: String = ""
 
-    weak var delegate: CentrifugeSubscriptionDelegate?
+    public weak var delegate: CentrifugeSubscriptionDelegate?
     
     private var callbacks: [String: ((Error?) -> ())] = [:]
     private let syncQueue: DispatchQueue


### PR DESCRIPTION
When a subscription already exists I get it with `client.getSubscription`. The returned subscription's delegate then needs to be set. In order to do this, the delegate needs to be public.
