### PR TITLE
Synchronize memory access, avoid duplicate state change events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.5.1
+=====
+
+* Fix crashes caused by non-synchronized memory access upon getting `no ping` disconnect
+* Fix issuing duplicate state change events
+
 0.5.0
 =====
 

--- a/SwiftCentrifuge.podspec
+++ b/SwiftCentrifuge.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
     s.name                  = 'SwiftCentrifuge'
     s.module_name           = 'SwiftCentrifuge'
     s.swift_version         = '5.0'
-    s.version               = '0.5.0'
+    s.version               = '0.5.1'
 
     s.homepage              = 'https://github.com/centrifugal/centrifuge-swift'
     s.summary               = 'Centrifugo and Centrifuge client in Swift'


### PR DESCRIPTION
Relates #68 

I was able to reproduce several crashes due to non synchronized memory access by stressing out some SDK paths - connecting, disconnecting, and having `no-ping` timer event in parallel. Using sync queue for `processDisconnect` call inside no ping timer callback crashes gone away.

Still possible that the root cause in #68 is different, but hopefully that was caused by missing synchronization of disconnect processing inside no ping handler.

Also fixing issuing duplicate events here – i.e. if SDK emitted `connecting` event, it must not emit it again while in connecting state.   