### PR TITLE
Improve logger API: replace String with StaticString

### DIFF
--- a/Example/SwiftCentrifuge/PrintLogger.swift
+++ b/Example/SwiftCentrifuge/PrintLogger.swift
@@ -12,10 +12,12 @@ import SwiftCentrifuge
 final class PrintLogger: CentrifugeLogger {
     func log(level: CentrifugeLoggerLevel,
              message: @autoclosure () -> String,
-             file: String,
-             function: String,
+             file: StaticString,
+             function: StaticString,
              line: UInt) {
-        let file = (URL(string: file)?.lastPathComponent) ?? file
-        print("[\(level)] \(file):\(line) \(message())")
+
+        let file = "\(file)"
+        let fileName = (URL(string: file)?.lastPathComponent) ?? file
+        print("[\(level)] \(fileName):\(line) \(message())")
     }
 }

--- a/Example/SwiftCentrifuge/ViewController.swift
+++ b/Example/SwiftCentrifuge/ViewController.swift
@@ -26,7 +26,8 @@ class ViewController: UIViewController {
         
         let config = CentrifugeClientConfig(
             token: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0c3VpdGVfand0In0.hPmHsVqvtY88PvK4EmJlcdwNuKFuy3BGaF7dMaKdPlw",
-            tokenGetter: self
+            tokenGetter: self,
+			logger: PrintLogger()
         )
         let url = "ws://127.0.0.1:8000/connection/websocket?cf_protocol=protobuf"
         self.client = CentrifugeClient(endpoint: url, config: config, delegate: self)

--- a/Sources/SwiftCentrifuge/Logger.swift
+++ b/Sources/SwiftCentrifuge/Logger.swift
@@ -18,43 +18,43 @@ public enum CentrifugeLoggerLevel {
 public protocol CentrifugeLogger {
     func log(level: CentrifugeLoggerLevel,
              message: @autoclosure () -> String,
-             file: String,
-             function: String,
+             file: StaticString,
+             function: StaticString,
              line: UInt)
 }
 
 public extension CentrifugeLogger {
     func trace(_ message: @autoclosure () -> String,
-               file: String = #file,
-               function: String = #function,
+               file: StaticString = #file,
+               function: StaticString = #function,
                line: UInt = #line) {
         log(level: .trace, message: message(), file: file, function: function, line: line)
     }
 
     func debug(_ message: @autoclosure () -> String,
-               file: String = #file,
-               function: String = #function,
+               file: StaticString = #file,
+               function: StaticString = #function,
                line: UInt = #line) {
         log(level: .debug, message: message(), file: file, function: function, line: line)
     }
 
     func info(_ message: @autoclosure () -> String,
-               file: String = #file,
-               function: String = #function,
+               file: StaticString = #file,
+               function: StaticString = #function,
                line: UInt = #line) {
         log(level: .info, message: message(), file: file, function: function, line: line)
     }
 
     func warning(_ message: @autoclosure () -> String,
-               file: String = #file,
-               function: String = #function,
+               file: StaticString = #file,
+               function: StaticString = #function,
                line: UInt = #line) {
         log(level: .warning, message: message(), file: file, function: function, line: line)
     }
 
     func error(_ message: @autoclosure () -> String,
-               file: String = #file,
-               function: String = #function,
+               file: StaticString = #file,
+               function: StaticString = #function,
                line: UInt = #line) {
         log(level: .error, message: message(), file: file, function: function, line: line)
     }
@@ -66,7 +66,7 @@ final class EmptyLogger: CentrifugeLogger {
 
     private init() {}
 
-    func log(level: CentrifugeLoggerLevel, message: @autoclosure () -> String, file: String, function: String, line: UInt) {
+    func log(level: CentrifugeLoggerLevel, message: @autoclosure () -> String, file: StaticString, function: StaticString, line: UInt) {
         // ignore
     }
 }


### PR DESCRIPTION
Replace `String` with `StaticString` for `file` and `function` parameters.
`StaticString` is more general, instances can be created only during compilation time (`String` can't be converted to `StaticString`).

Some logger libraries actually use `StaticString`. This PR makes it easier to integrate those libraries.