### PR TITLE
Prevent memory leak

### DIFF
--- a/Sources/SwiftCentrifuge/Client.swift
+++ b/Sources/SwiftCentrifuge/Client.swift
@@ -25,7 +25,7 @@ public enum CentrifugeError: Error {
     case replyError(code: UInt32, message: String, temporary: Bool)
 }
 
-public protocol CentrifugeConnectionTokenGetter {
+public protocol CentrifugeConnectionTokenGetter: NSObject {
     func getConnectionToken(_ event: CentrifugeConnectionTokenEvent, completion: @escaping (Result<String, Error>) -> ())
 }
 
@@ -56,7 +56,7 @@ public struct CentrifugeClientConfig {
     public var name = "swift"
     public var version = ""
     public var token: String = ""
-    public var tokenGetter: CentrifugeConnectionTokenGetter?
+    public weak var tokenGetter: CentrifugeConnectionTokenGetter?
     public var data: Data? = nil
     public var debug: Bool = false
 	public var logger: CentrifugeLogger?

--- a/Sources/SwiftCentrifuge/Subscription.swift
+++ b/Sources/SwiftCentrifuge/Subscription.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public protocol CentrifugeSubscriptionTokenGetter {
+public protocol CentrifugeSubscriptionTokenGetter: NSObject {
     func getSubscriptionToken(_ event: CentrifugeSubscriptionTokenEvent, completion: @escaping (Result<String, Error>) -> ())
 }
 
@@ -33,7 +33,7 @@ public struct CentrifugeSubscriptionConfig {
     public var positioned: Bool = false
     public var recoverable: Bool = false
     public var joinLeave: Bool = false
-    public var tokenGetter: CentrifugeSubscriptionTokenGetter?
+    public weak var tokenGetter: CentrifugeSubscriptionTokenGetter?
 }
 
 public enum CentrifugeSubscriptionState {


### PR DESCRIPTION
Change the TokenGetter to a weak reference to prevent a memory leak in the client.

The client holds the `CentrifugeClientConfig` which has a strong reference to a `CentrifugeConnectionTokenGetter`
The problem can happen once the `CentrifugeConnectionTokenGetter` implementation is the one that is holding a strong reference to the `Client`.

This creates a circular strong reference Between the App -> Client -> Config -> TokenGetter -> App