### PR TITLE
Compatibility with SwiftProtobuf 1.27.0 and older versions

### DIFF
--- a/Sources/SwiftCentrifuge/Client.swift
+++ b/Sources/SwiftCentrifuge/Client.swift
@@ -892,17 +892,21 @@ fileprivate extension CentrifugeClient {
     }
     
     private func handleData(data: Data) {
-        guard let replies = try? CentrifugeSerializer.deserializeCommands(data: data) else { return }
-        for reply in replies {
-            if reply.id > 0 {
-                self.opCallbacks[reply.id]?(CentrifugeResolveData(error: nil, reply: reply))
-            } else {
-                if !reply.hasPush {
-                    self.handlePing()
+        do {
+            let replies = try CentrifugeSerializer.deserializeCommands(data: data)
+            for reply in replies {
+                if reply.id > 0 {
+                    self.opCallbacks[reply.id]?(CentrifugeResolveData(error: nil, reply: reply))
                 } else {
-                    self.handlePush(push: reply.push)
+                    if !reply.hasPush {
+                        self.handlePing()
+                    } else {
+                        self.handlePush(push: reply.push)
+                    }
                 }
             }
+        } catch {
+            self.log.error("error deserializeCommands: \(error)")
         }
     }
     


### PR DESCRIPTION
Relates #101 

SwiftProtobuf changed the behaviour and now returns noBytesAvailable error at the end of stream. Here we become independent from SwiftProtobuf 's `BinaryDelimited.parse` when decoding varint-delimited messages. It works on old versions and new version.