### PR TITLE
Fix incorrect handshake headers used for protocol negotiation

### DIFF
--- a/Sources/SwiftCentrifuge/WebSocket/NativeWebSocket.swift
+++ b/Sources/SwiftCentrifuge/WebSocket/NativeWebSocket.swift
@@ -27,7 +27,7 @@ final class NativeWebSocket: NSObject, WebSocketInterface, URLSessionWebSocketDe
 
     init(request: URLRequest, urlSessionConfigurationProvider: URLSessionConfigurationProvider?,  queue: DispatchQueue, log: CentrifugeLogger) {
         var request = request
-        request.setValue("Sec-WebSocket-Protocol", forHTTPHeaderField: "centrifuge-protobuf")
+        request.setValue("centrifuge-protobuf", forHTTPHeaderField: "Sec-WebSocket-Protocol")
         self.request = request
         self.log = log
         self.urlSessionConfigurationProvider = urlSessionConfigurationProvider ?? { URLSessionConfiguration.default }


### PR DESCRIPTION
Closes #120

Currently using `URLSessionWebSocketTask` from `NativeWebSocket` sets the incorrect protocol negotiation header.

This PR fixes this.