### PR TITLE
Fix CI: upgrade to macos-14 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,18 +3,12 @@ on: [push, pull_request]
 jobs:
   test:
     name: Test
-    runs-on: macos-13
+    runs-on: macos-14
     # Prevent duplicate builds on internal PRs.
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-    strategy:
-      matrix:
-        swift: ["5.9"]
     steps:
-      - uses: fwal/setup-swift@v1
-        with:
-          swift-version: ${{ matrix.swift }}    
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build
         run: swift build
       - name: Run tests


### PR DESCRIPTION
## Summary
- Upgrade from `macos-13` to `macos-14` runner (macos-13 is no longer supported)
- Remove `fwal/setup-swift` action (Swift is pre-installed on macos-14 runners)
- Bump `actions/checkout` from v2 to v4

## Test plan
- [ ] Verify CI passes on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)