### PR TITLE
Support publication filtering by tags

### DIFF
--- a/Sources/SwiftCentrifuge/Client.swift
+++ b/Sources/SwiftCentrifuge/Client.swift
@@ -24,6 +24,7 @@ public enum CentrifugeError: Error {
     case subscriptionGetStateError(error: Error)
     case subscriptionRefreshError(error: Error)
     case replyError(code: UInt32, message: String, temporary: Bool)
+    case configurationError(message: String)
 }
 
 public typealias CentrifugeConnectionTokenGetter = (_ event: CentrifugeConnectionTokenEvent, _ completion: @escaping (Result<String, Error>) -> Void) -> Void
@@ -328,6 +329,9 @@ public class CentrifugeClient: @unchecked Sendable {
         defer { subscriptionsLock.unlock() }
         subscriptionsLock.lock()
         guard !self.subscriptions.contains(where: { $0.channel == channel }) else { throw CentrifugeError.duplicateSub }
+        if let config, config.delta != nil, config.tagsFilter != nil {
+            throw CentrifugeError.configurationError(message: "cannot use delta and tags filter together")
+        }
         let sub = CentrifugeSubscription(
             centrifuge: self,
             channel: channel,
@@ -616,8 +620,8 @@ internal extension CentrifugeClient {
         subscriptionsLock.unlock()
     }
     
-    func subscribe(channel: String, token: String, delta: String?, data: Data?, recover: Bool, streamPosition: StreamPosition, positioned: Bool, recoverable: Bool, joinLeave: Bool, flag: Int64, completion: @escaping (Centrifugal_Centrifuge_Protocol_SubscribeResult?, Error?)->()) {
-        self.sendSubscribe(channel: channel, token: token, delta: delta, data: data, recover: recover, streamPosition: streamPosition, positioned: positioned, recoverable: recoverable, joinLeave: joinLeave, flag: flag, completion: completion)
+    func subscribe(channel: String, token: String, delta: String?, tagsFilter: CentrifugeFilterNode?, data: Data?, recover: Bool, streamPosition: StreamPosition, positioned: Bool, recoverable: Bool, joinLeave: Bool, flag: Int64, completion: @escaping (Centrifugal_Centrifuge_Protocol_SubscribeResult?, Error?)->()) {
+        self.sendSubscribe(channel: channel, token: token, delta: delta, tagsFilter: tagsFilter, data: data, recover: recover, streamPosition: streamPosition, positioned: positioned, recoverable: recoverable, joinLeave: joinLeave, flag: flag, completion: completion)
     }
     
     func reconnect(code: UInt32, reason: String) {
@@ -1264,7 +1268,7 @@ fileprivate extension CentrifugeClient {
         })
     }
     
-    private func sendSubscribe(channel: String, token: String, delta: String?, data: Data?, recover: Bool, streamPosition: StreamPosition, positioned: Bool, recoverable: Bool, joinLeave: Bool, flag: Int64, completion: @escaping (Centrifugal_Centrifuge_Protocol_SubscribeResult?, Error?)->()) {
+    private func sendSubscribe(channel: String, token: String, delta: String?, tagsFilter: CentrifugeFilterNode?, data: Data?, recover: Bool, streamPosition: StreamPosition, positioned: Bool, recoverable: Bool, joinLeave: Bool, flag: Int64, completion: @escaping (Centrifugal_Centrifuge_Protocol_SubscribeResult?, Error?)->()) {
         var req = Centrifugal_Centrifuge_Protocol_SubscribeRequest()
         req.channel = channel
         if recover {
@@ -1278,6 +1282,9 @@ fileprivate extension CentrifugeClient {
         req.flag = flag
         if let delta {
             req.delta = delta
+        }
+        if let tagsFilter {
+            req.tf = tagsFilter.node
         }
         if data != nil {
             req.data = data!

--- a/Sources/SwiftCentrifuge/Filter.swift
+++ b/Sources/SwiftCentrifuge/Filter.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+/// A node in a publication tags-filter expression tree, used for server-side
+/// publication filtering. Build instances with the ``CentrifugeFilter`` helpers
+/// and pass the result via ``CentrifugeSubscriptionConfig/tagsFilter`` or
+/// ``CentrifugeSubscription/setTagsFilter(_:)``.
+///
+/// A filter is either a leaf node (a comparison such as `ticker == "AAPL"`) or a
+/// logical node combining child nodes with and/or/not. The server evaluates the
+/// filter against each publication's tags and delivers only matching
+/// publications. See https://centrifugal.dev/docs/server/publication_filtering.
+///
+/// Publication filtering must be enabled for the namespace on the server
+/// (`allow_tags_filter`) and cannot be combined with delta compression.
+public struct CentrifugeFilterNode {
+    let node: Centrifugal_Centrifuge_Protocol_FilterNode
+
+    init(_ node: Centrifugal_Centrifuge_Protocol_FilterNode) {
+        self.node = node
+    }
+}
+
+/// Builders for ``CentrifugeFilterNode`` expressions. Comparison helpers create
+/// leaf nodes; ``and(_:)``, ``or(_:)`` and ``not(_:)`` combine them.
+///
+/// ```swift
+/// // (ticker == "AAPL") AND (price >= "100") AND (source in ["NASDAQ", "NYSE"])
+/// let filter = CentrifugeFilter.and([
+///     CentrifugeFilter.eq("ticker", "AAPL"),
+///     CentrifugeFilter.gte("price", "100"),
+///     CentrifugeFilter.inList("source", ["NASDAQ", "NYSE"]),
+/// ])
+/// ```
+public enum CentrifugeFilter {
+    private static func leaf(_ key: String, _ cmp: String, val: String? = nil, vals: [String]? = nil) -> CentrifugeFilterNode {
+        var node = Centrifugal_Centrifuge_Protocol_FilterNode()
+        node.key = key
+        node.cmp = cmp
+        if let val { node.val = val }
+        if let vals { node.vals = vals }
+        return CentrifugeFilterNode(node)
+    }
+
+    private static func logical(_ op: String, _ nodes: [CentrifugeFilterNode]) -> CentrifugeFilterNode {
+        var node = Centrifugal_Centrifuge_Protocol_FilterNode()
+        node.op = op
+        node.nodes = nodes.map { $0.node }
+        return CentrifugeFilterNode(node)
+    }
+
+    /// Tag `key` equals `val`.
+    public static func eq(_ key: String, _ val: String) -> CentrifugeFilterNode { leaf(key, "eq", val: val) }
+
+    /// Tag `key` does not equal `val`.
+    public static func neq(_ key: String, _ val: String) -> CentrifugeFilterNode { leaf(key, "neq", val: val) }
+
+    /// Tag `key` is one of `vals`.
+    public static func inList(_ key: String, _ vals: [String]) -> CentrifugeFilterNode { leaf(key, "in", vals: vals) }
+
+    /// Tag `key` is not one of `vals`.
+    public static func notInList(_ key: String, _ vals: [String]) -> CentrifugeFilterNode { leaf(key, "nin", vals: vals) }
+
+    /// Tag `key` exists.
+    public static func exists(_ key: String) -> CentrifugeFilterNode { leaf(key, "ex") }
+
+    /// Tag `key` does not exist.
+    public static func notExists(_ key: String) -> CentrifugeFilterNode { leaf(key, "nex") }
+
+    /// String tag `key` starts with `val`.
+    public static func startsWith(_ key: String, _ val: String) -> CentrifugeFilterNode { leaf(key, "sw", val: val) }
+
+    /// String tag `key` ends with `val`.
+    public static func endsWith(_ key: String, _ val: String) -> CentrifugeFilterNode { leaf(key, "ew", val: val) }
+
+    /// String tag `key` contains `val`.
+    public static func contains(_ key: String, _ val: String) -> CentrifugeFilterNode { leaf(key, "ct", val: val) }
+
+    /// Numeric tag `key` is greater than `val`.
+    public static func gt(_ key: String, _ val: String) -> CentrifugeFilterNode { leaf(key, "gt", val: val) }
+
+    /// Numeric tag `key` is greater than or equal to `val`.
+    public static func gte(_ key: String, _ val: String) -> CentrifugeFilterNode { leaf(key, "gte", val: val) }
+
+    /// Numeric tag `key` is less than `val`.
+    public static func lt(_ key: String, _ val: String) -> CentrifugeFilterNode { leaf(key, "lt", val: val) }
+
+    /// Numeric tag `key` is less than or equal to `val`.
+    public static func lte(_ key: String, _ val: String) -> CentrifugeFilterNode { leaf(key, "lte", val: val) }
+
+    /// All `nodes` must match.
+    public static func and(_ nodes: [CentrifugeFilterNode]) -> CentrifugeFilterNode { logical("and", nodes) }
+
+    /// At least one of `nodes` must match.
+    public static func or(_ nodes: [CentrifugeFilterNode]) -> CentrifugeFilterNode { logical("or", nodes) }
+
+    /// Inverts `node`.
+    public static func not(_ node: CentrifugeFilterNode) -> CentrifugeFilterNode { logical("not", [node]) }
+}

--- a/Sources/SwiftCentrifuge/Subscription.swift
+++ b/Sources/SwiftCentrifuge/Subscription.swift
@@ -18,7 +18,7 @@ public enum DeltaType: String {
 }
 
 public struct CentrifugeSubscriptionConfig {
-    public init(minResubscribeDelay: Double = 0.5, maxResubscribeDelay: Double = 20.0, token: String = "", data: Data? = nil, since: CentrifugeStreamPosition? = nil, positioned: Bool = false, recoverable: Bool = false, joinLeave: Bool = false, tokenGetter: CentrifugeSubscriptionTokenGetter? = nil, delta: DeltaType? = nil, stateGetter: CentrifugeSubscriptionStateGetter? = nil) {
+    public init(minResubscribeDelay: Double = 0.5, maxResubscribeDelay: Double = 20.0, token: String = "", data: Data? = nil, since: CentrifugeStreamPosition? = nil, positioned: Bool = false, recoverable: Bool = false, joinLeave: Bool = false, tokenGetter: CentrifugeSubscriptionTokenGetter? = nil, delta: DeltaType? = nil, tagsFilter: CentrifugeFilterNode? = nil, stateGetter: CentrifugeSubscriptionStateGetter? = nil) {
         self.minResubscribeDelay = minResubscribeDelay
         self.maxResubscribeDelay = maxResubscribeDelay
         self.token = token
@@ -29,6 +29,7 @@ public struct CentrifugeSubscriptionConfig {
         self.recoverable = recoverable
         self.joinLeave = joinLeave
         self.delta = delta
+        self.tagsFilter = tagsFilter
         self.stateGetter = stateGetter
     }
 
@@ -36,6 +37,11 @@ public struct CentrifugeSubscriptionConfig {
     public var maxResubscribeDelay = 20.0
     public var token: String = ""
     public var delta: DeltaType? = nil
+    /// Server-side publication filter based on publication tags. When set, the
+    /// server delivers only publications whose tags match the filter. Must be
+    /// enabled for the namespace on the server (`allow_tags_filter`) and cannot
+    /// be combined with `delta`. Build with the ``CentrifugeFilter`` helpers.
+    public var tagsFilter: CentrifugeFilterNode? = nil
     public var data: Data? = nil
     public var since: CentrifugeStreamPosition? = nil
     public var positioned: Bool = false
@@ -99,6 +105,7 @@ public class CentrifugeSubscription: @unchecked Sendable {
     
     fileprivate var token: String?
     fileprivate var delta: String?
+    fileprivate var tagsFilter: CentrifugeFilterNode?
     fileprivate var deltaNegotiated: Bool = false
     fileprivate var refreshTask: DispatchWorkItem?
     fileprivate var resubscribeTask: DispatchWorkItem?
@@ -125,6 +132,7 @@ public class CentrifugeSubscription: @unchecked Sendable {
         if (config.delta != nil) {
             self.delta = config.delta?.rawValue
         }
+        self.tagsFilter = config.tagsFilter
         if (config.token != "") {
             self.token = config.token;
         }
@@ -139,6 +147,19 @@ public class CentrifugeSubscription: @unchecked Sendable {
         }
     }
     
+    /// Sets the server-side publication tags filter. Applied on the next
+    /// subscribe attempt, not the current one. Pass `nil` to clear it. Cannot be
+    /// combined with delta compression. Build with the ``CentrifugeFilter`` helpers.
+    /// - Throws: ``CentrifugeError/configurationError(message:)`` if delta is enabled.
+    public func setTagsFilter(_ tagsFilter: CentrifugeFilterNode?) throws {
+        if tagsFilter != nil && self.delta != nil {
+            throw CentrifugeError.configurationError(message: "cannot use delta and tags filter together")
+        }
+        self.centrifuge?.syncQueue.sync {
+            self.tagsFilter = tagsFilter
+        }
+    }
+
     public func subscribe() {
         self.centrifuge?.syncQueue.async { [weak self] in
             guard
@@ -224,7 +245,7 @@ public class CentrifugeSubscription: @unchecked Sendable {
             // recovered=false — so we can call the state getter again to reload state.
             flag |= subscriptionFlagRejectUnrecovered
         }
-        self.centrifuge?.subscribe(channel: self.channel, token: token, delta: self.delta, data: self.config.data, recover: self.recover, streamPosition: streamPosition, positioned: self.config.positioned, recoverable: self.config.recoverable, joinLeave: self.config.joinLeave, flag: flag, completion: { [weak self, weak centrifuge = self.centrifuge] res, error in
+        self.centrifuge?.subscribe(channel: self.channel, token: token, delta: self.delta, tagsFilter: self.tagsFilter, data: self.config.data, recover: self.recover, streamPosition: streamPosition, positioned: self.config.positioned, recoverable: self.config.recoverable, joinLeave: self.config.joinLeave, flag: flag, completion: { [weak self, weak centrifuge = self.centrifuge] res, error in
             guard let centrifuge = centrifuge else { return }
             guard let strongSelf = self else { return }
             guard strongSelf.state == .subscribing else { return }

--- a/Tests/SwiftCentrifugeTests/FilterTests.swift
+++ b/Tests/SwiftCentrifugeTests/FilterTests.swift
@@ -1,0 +1,144 @@
+import XCTest
+import Network
+import SwiftProtobuf
+@testable import SwiftCentrifuge
+
+/// Tests for publication filtering (server-side filtering by publication tags).
+/// The CentrifugeFilter builders construct a protocol FilterNode tree; the
+/// subscribe request carries it in the `tf` field. The feature requires
+/// Centrifugo PRO / namespace config, so wire-level behavior is exercised against
+/// the in-process FakeCentrifugoServer.
+///
+/// Run with full Xcode toolchain (XCTest is unavailable under CommandLineTools):
+///     swift test --filter FilterTests
+final class FilterTests: XCTestCase {
+
+    private final class SubDelegate: CentrifugeSubscriptionDelegate {
+        var onSub: ((CentrifugeSubscribedEvent) -> Void)?
+        func onSubscribed(_ s: CentrifugeSubscription, _ e: CentrifugeSubscribedEvent) { onSub?(e) }
+    }
+
+    private var server: FakeCentrifugoServer!
+
+    override func setUpWithError() throws {
+        server = FakeCentrifugoServer()
+        try server.start()
+    }
+
+    override func tearDown() {
+        server.stop()
+    }
+
+    private func makeClient() -> CentrifugeClient {
+        var cfg = CentrifugeClientConfig()
+        cfg.minReconnectDelay = 0.05
+        cfg.maxReconnectDelay = 0.2
+        return CentrifugeClient(endpoint: server.url, config: cfg)
+    }
+
+    func testBuilderLeafAndLogicalNodes() {
+        let eq = CentrifugeFilter.eq("ticker", "AAPL").node
+        XCTAssertEqual(eq.key, "ticker")
+        XCTAssertEqual(eq.cmp, "eq")
+        XCTAssertEqual(eq.val, "AAPL")
+
+        let inNode = CentrifugeFilter.inList("category", ["tech", "finance"]).node
+        XCTAssertEqual(inNode.cmp, "in")
+        XCTAssertEqual(inNode.vals, ["tech", "finance"])
+        XCTAssertEqual(CentrifugeFilter.notInList("t", ["MSFT"]).node.cmp, "nin")
+
+        XCTAssertEqual(CentrifugeFilter.exists("price").node.cmp, "ex")
+        XCTAssertEqual(CentrifugeFilter.notExists("id").node.cmp, "nex")
+        XCTAssertEqual(CentrifugeFilter.startsWith("t", "AA").node.cmp, "sw")
+        XCTAssertEqual(CentrifugeFilter.endsWith("s", "Q").node.cmp, "ew")
+        XCTAssertEqual(CentrifugeFilter.contains("c", "ec").node.cmp, "ct")
+        XCTAssertEqual(CentrifugeFilter.gt("p", "1").node.cmp, "gt")
+        XCTAssertEqual(CentrifugeFilter.gte("p", "1").node.cmp, "gte")
+        XCTAssertEqual(CentrifugeFilter.lt("p", "1").node.cmp, "lt")
+        XCTAssertEqual(CentrifugeFilter.lte("p", "1").node.cmp, "lte")
+
+        let and = CentrifugeFilter.and([
+            CentrifugeFilter.eq("ticker", "AAPL"),
+            CentrifugeFilter.gte("price", "100"),
+            CentrifugeFilter.inList("source", ["NASDAQ", "NYSE"]),
+        ]).node
+        XCTAssertEqual(and.op, "and")
+        XCTAssertEqual(and.nodes.count, 3)
+        XCTAssertEqual(and.nodes[0].key, "ticker")
+        XCTAssertEqual(and.nodes[2].cmp, "in")
+
+        let or = CentrifugeFilter.or([CentrifugeFilter.eq("a", "1"), CentrifugeFilter.eq("b", "2")]).node
+        XCTAssertEqual(or.op, "or")
+        XCTAssertEqual(or.nodes.count, 2)
+
+        let not = CentrifugeFilter.not(CentrifugeFilter.eq("s", "NYSE")).node
+        XCTAssertEqual(not.op, "not")
+        XCTAssertEqual(not.nodes.count, 1)
+        XCTAssertEqual(not.nodes[0].cmp, "eq")
+    }
+
+    func testSubscribeRequestCarriesTagsFilter() throws {
+        let client = makeClient()
+        client.connect()
+        defer { client.disconnect() }
+        let d = SubDelegate()
+        let subscribed = expectation(description: "subscribed")
+        d.onSub = { _ in subscribed.fulfill() }
+        let cfg = CentrifugeSubscriptionConfig(tagsFilter: CentrifugeFilter.and([
+            CentrifugeFilter.eq("ticker", "AAPL"),
+            CentrifugeFilter.gte("price", "100"),
+        ]))
+        let sub = try client.newSubscription(channel: "market", delegate: d, config: cfg)
+        sub.subscribe()
+        wait(for: [subscribed], timeout: 5)
+
+        let tf = try XCTUnwrap(server.lastSubscribe()?.tf)
+        XCTAssertEqual(tf.op, "and")
+        XCTAssertEqual(tf.nodes.count, 2)
+        XCTAssertEqual(tf.nodes[0].key, "ticker")
+        XCTAssertEqual(tf.nodes[0].cmp, "eq")
+        XCTAssertEqual(tf.nodes[0].val, "AAPL")
+        XCTAssertEqual(tf.nodes[1].cmp, "gte")
+    }
+
+    func testSetTagsFilterAppliesOnSubscribe() throws {
+        let client = makeClient()
+        client.connect()
+        defer { client.disconnect() }
+        let d = SubDelegate()
+        let subscribed = expectation(description: "subscribed")
+        d.onSub = { _ in subscribed.fulfill() }
+        let sub = try client.newSubscription(channel: "market", delegate: d)
+        try sub.setTagsFilter(CentrifugeFilter.eq("ticker", "BTC"))
+        sub.subscribe()
+        wait(for: [subscribed], timeout: 5)
+
+        let tf = try XCTUnwrap(server.lastSubscribe()?.tf)
+        XCTAssertEqual(tf.key, "ticker")
+        XCTAssertEqual(tf.val, "BTC")
+    }
+
+    func testSubscribeWithoutFilterSendsNoTf() throws {
+        let client = makeClient()
+        client.connect()
+        defer { client.disconnect() }
+        let d = SubDelegate()
+        let subscribed = expectation(description: "subscribed")
+        d.onSub = { _ in subscribed.fulfill() }
+        let sub = try client.newSubscription(channel: "market", delegate: d)
+        sub.subscribe()
+        wait(for: [subscribed], timeout: 5)
+
+        XCTAssertFalse(server.lastSubscribe()?.hasTf ?? true)
+    }
+
+    func testDeltaAndTagsFilterCannotCombine() throws {
+        let client = makeClient()
+        let cfg = CentrifugeSubscriptionConfig(delta: .fossil, tagsFilter: CentrifugeFilter.eq("a", "1"))
+        XCTAssertThrowsError(try client.newSubscription(channel: "market", delegate: SubDelegate(), config: cfg))
+
+        let sub = try client.newSubscription(channel: "market2", delegate: SubDelegate(),
+                                             config: CentrifugeSubscriptionConfig(delta: .fossil))
+        XCTAssertThrowsError(try sub.setTagsFilter(CentrifugeFilter.eq("a", "1")))
+    }
+}


### PR DESCRIPTION
Adds support for [publication filtering](https://centrifugal.dev/docs/server/publication_filtering) by publication tags.

A subscription can carry a tags filter so the server delivers only publications whose tags match it — reducing bandwidth and client-side processing.

### API

- `CentrifugeFilter` builders: `eq`, `neq`, `inList`, `notInList`, `exists`, `notExists`, `startsWith`, `endsWith`, `contains`, `gt`, `gte`, `lt`, `lte`, `and`, `or`, `not`.
- `CentrifugeSubscriptionConfig.tagsFilter` to set at creation.
- `Subscription.setTagsFilter(...)` to set/replace before the next subscribe (throws if delta is enabled).
- Mutually exclusive with delta compression (validated).

### Example

```swift
let cfg = CentrifugeSubscriptionConfig(tagsFilter: CentrifugeFilter.and([
    CentrifugeFilter.eq("ticker", "AAPL"),
    CentrifugeFilter.gte("price", "100"),
]))
let sub = try client.newSubscription(channel: "market:stocks", delegate: delegate, config: cfg)
```

Tests added in `FilterTests.swift`: builder unit tests plus fake-server wire tests asserting the subscribe request carries the `tf` field (and sends none when unset).
