### PR TITLE
Support state invalidation

### DIFF
--- a/Sources/SwiftCentrifuge/Client.swift
+++ b/Sources/SwiftCentrifuge/Client.swift
@@ -965,6 +965,11 @@ fileprivate extension CentrifugeClient {
         if (unsubscribe.code < 2500) {
             sub.processUnsubscribe(sendUnsubscribe: false, code: unsubscribe.code, reason: unsubscribe.reason)
         } else {
+            if unsubscribe.code == unsubscribedStateInvalidated {
+                // State invalidated: drop the subscription token and cached state
+                // so the resubscribe below obtains a fresh token and re-syncs.
+                sub.invalidateState()
+            }
             sub.moveToSubscribingUponDisconnect(code: unsubscribe.code, reason: unsubscribe.reason)
             sub.resubscribeIfNecessary()
         }
@@ -1136,6 +1141,20 @@ fileprivate extension CentrifugeClient {
         // pushId is left as-is: the next subscribe reply re-registers it regardless
         // of whether the server reuses the same ID.
         self.subscriptionsById.removeAll()
+
+        if code == disconnectedStateInvalidated {
+            // State invalidated (delivered as a WebSocket close code or a Disconnect
+            // push — both funnel here): drop the connection token so the next connect
+            // fetches a fresh one via the token getter, and invalidate every
+            // subscription's cached state before they move to subscribing below.
+            self.token = ""
+            self.refreshRequired = true
+            subscriptionsLock.lock()
+            for sub in self.subscriptions {
+                sub.invalidateState()
+            }
+            subscriptionsLock.unlock()
+        }
 
         for resolveFunc in self.opCallbacks.values {
             resolveFunc(CentrifugeResolveData(error: CentrifugeError.clientDisconnected, reply: nil))

--- a/Sources/SwiftCentrifuge/Codes.swift
+++ b/Sources/SwiftCentrifuge/Codes.swift
@@ -38,6 +38,15 @@ let subscriptionFlagRejectUnrecovered: Int64 = 2
 // impossible (only sent when subscriptionFlagRejectUnrecovered was requested).
 let errorCodeUnrecoverablePosition: UInt32 = 112
 
+// Server-sent "state invalidated" codes. The server determines that the client's
+// cached state and/or token are no longer valid and asks the client to drop them
+// and re-sync. 2502 arrives in an Unsubscribe push for a single subscription (the
+// client clears the subscription state and resubscribes, since it's >= 2500); 3014
+// arrives for the whole connection (the client clears the connection token to force
+// a fresh one via the token getter, invalidates all subscriptions, reconnects).
+let unsubscribedStateInvalidated: UInt32 = 2502
+let disconnectedStateInvalidated: UInt32 = 3014
+
 func interpretCloseCode(_ code: UInt32) -> (code: UInt32, reconnect: Bool) {
     // We act according to Disconnect code semantics.
     // See https://github.com/centrifugal/centrifuge/blob/master/disconnect.go.

--- a/Sources/SwiftCentrifuge/Subscription.swift
+++ b/Sources/SwiftCentrifuge/Subscription.swift
@@ -670,4 +670,29 @@ public class CentrifugeSubscription: @unchecked Sendable {
         self.pushId = id
         self.centrifuge?.updateSubscriptionPushId(sub: self, oldId: oldId, newId: id)
     }
+
+    // Resets cached subscription state on "state invalidated" (unsubscribe code
+    // 2502 or connection disconnect code 3014) so the resubscribe starts from
+    // scratch: clears the token (next subscribe fetches a fresh one via the token
+    // getter when configured, else resubscribes with an empty token), the recovery
+    // position (offset/epoch/recover — forcing a full re-sync from the head instead
+    // of stream recovery), the fossil delta base (a stale base would corrupt
+    // decoding of the first publication), and the channel-compaction ID mapping.
+    // Runs on the client syncQueue.
+    func invalidateState() {
+        // nil token routes the next resubscribe through the token getter when one
+        // is configured, and otherwise falls through to an empty-token subscribe
+        // (continueResubscribe handles both) — i.e. a fresh token, never the stale one.
+        self.token = nil
+        // Reset the recovery position to a sentinel epoch ("_") the server can
+        // never match (offset 0); leave the recover flag untouched. A recoverable
+        // subscription then resubscribes with wasRecovering=true, recovered=false
+        // (app reloads via its recovery-failure path); a non-recoverable one just
+        // resubscribes (the sentinel is not sent). The real epoch/offset are
+        // adopted from the subscribe reply.
+        self.offset = 0
+        self.epoch = "_"
+        self.prevValue = nil
+        self.setPushId(0)
+    }
 }

--- a/Tests/SwiftCentrifugeTests/FakeCentrifugoServer.swift
+++ b/Tests/SwiftCentrifugeTests/FakeCentrifugoServer.swift
@@ -166,6 +166,29 @@ final class FakeCentrifugoServer: @unchecked Sendable {
     /// Send a raw push (wrapped in a reply) to the active connection.
     func sendPush(_ push: PPush) { var r = PReply(); r.push = push; sendReply(r) }
 
+    /// Send a Disconnect push (e.g. code 3014 state invalidated). Centrifugo can
+    /// also deliver disconnects as WebSocket close frames; both funnel through the
+    /// client's processDisconnect.
+    func disconnect(_ code: UInt32, _ reason: String) {
+        var d = Centrifugal_Centrifuge_Protocol_Disconnect()
+        d.code = code
+        d.reason = reason
+        var push = PPush()
+        push.disconnect = d
+        sendPush(push)
+    }
+
+    /// Send an Unsubscribe push for a channel (e.g. code 2502 state invalidated).
+    func unsubscribe(_ channel: String, _ code: UInt32, _ reason: String) {
+        var u = Centrifugal_Centrifuge_Protocol_Unsubscribe()
+        u.code = code
+        u.reason = reason
+        var push = PPush()
+        push.channel = channel
+        push.unsubscribe = u
+        sendPush(push)
+    }
+
     // --- typed push senders ---------------------------------------------------
     //
     // Channel compaction pushes carry a numeric id and no channel; otherwise the

--- a/Tests/SwiftCentrifugeTests/StateInvalidationTests.swift
+++ b/Tests/SwiftCentrifugeTests/StateInvalidationTests.swift
@@ -1,0 +1,162 @@
+import XCTest
+import Network
+import SwiftProtobuf
+@testable import SwiftCentrifuge
+
+/// Tests for "state invalidated" handling: unsubscribe code 2502 (per-subscription)
+/// and disconnect code 3014 (connection-wide). On these the client drops cached
+/// tokens (and recovery position / delta base) so a fresh token is obtained and
+/// the subscription re-syncs. Private subscription fields aren't readable, so
+/// behavior is asserted over the wire against the in-process FakeCentrifugoServer.
+///
+/// Run with full Xcode toolchain (XCTest is unavailable under CommandLineTools):
+///     swift test --filter StateInvalidationTests
+final class StateInvalidationTests: XCTestCase {
+
+    private final class SubDelegate: CentrifugeSubscriptionDelegate {
+        var onSub: (() -> Void)?
+        func onSubscribed(_ s: CentrifugeSubscription, _ e: CentrifugeSubscribedEvent) { onSub?() }
+    }
+
+    private final class ClientDelegate: CentrifugeClientDelegate {
+        var onConn: (() -> Void)?
+        func onConnected(_ c: CentrifugeClient, _ e: CentrifugeConnectedEvent) { onConn?() }
+    }
+
+    private final class Counter: @unchecked Sendable {
+        private let lock = NSLock()
+        private var n = 0
+        func next() -> Int { lock.lock(); defer { lock.unlock() }; n += 1; return n }
+        func count() -> Int { lock.lock(); defer { lock.unlock() }; return n }
+    }
+
+    private var server: FakeCentrifugoServer!
+
+    override func setUpWithError() throws {
+        server = FakeCentrifugoServer()
+        try server.start()
+    }
+
+    override func tearDown() {
+        server.stop()
+    }
+
+    private func lastSubscribeToken() -> String? {
+        server.received().last(where: { $0.hasSubscribe })?.subscribe.token
+    }
+
+    private func lastConnectToken() -> String? {
+        server.received().last(where: { $0.hasConnect })?.connect.token
+    }
+
+    func testUnsubscribe2502ClearsTokenAndResubscribes() throws {
+        let client = CentrifugeClient(endpoint: server.url, config: CentrifugeClientConfig())
+        client.connect()
+        defer { client.disconnect() }
+
+        let counter = Counter()
+        let subscribed = expectation(description: "subscribed")
+        subscribed.expectedFulfillmentCount = 2  // initial + resubscribe
+        subscribed.assertForOverFulfill = false
+        let d = SubDelegate()
+        d.onSub = { subscribed.fulfill() }
+        var cfg = CentrifugeSubscriptionConfig()
+        cfg.tokenGetter = { _, completion in completion(.success("t\(counter.next())")) }
+        let sub = try client.newSubscription(channel: "ch", delegate: d, config: cfg)
+        sub.subscribe()
+
+        // Wait for the first subscribe, assert it used the first fetched token.
+        let firstSubscribed = expectation(description: "first subscribed")
+        d.onSub = {
+            firstSubscribed.fulfill()
+            d.onSub = { subscribed.fulfill() }
+        }
+        wait(for: [firstSubscribed], timeout: 5)
+        XCTAssertEqual(lastSubscribeToken(), "t1")
+
+        server.unsubscribe("ch", unsubscribedStateInvalidated, "state invalidated")
+        wait(for: [subscribed], timeout: 5)
+        XCTAssertEqual(lastSubscribeToken(), "t2", "2502 must clear token so resubscribe fetches a fresh one")
+        XCTAssertEqual(counter.count(), 2)
+    }
+
+    func testUnsubscribe2502RecoverableResubscribesUnrecovered() throws {
+        // A recoverable subscription must resubscribe REQUESTING recovery from the
+        // sentinel epoch "_" the server can't match → wasRecovering=true,
+        // recovered=false (so the app reloads via its recovery-failure path).
+        server.onSubscribe = { _, _ in
+            var r = FakeCentrifugoServer.PSubscribeResult()
+            r.recoverable = true
+            r.epoch = "server-epoch"
+            r.offset = 5
+            return r
+        }
+        let client = CentrifugeClient(endpoint: server.url, config: CentrifugeClientConfig())
+        client.connect()
+        defer { client.disconnect() }
+
+        let subscribed = expectation(description: "subscribed")
+        subscribed.expectedFulfillmentCount = 2
+        subscribed.assertForOverFulfill = false
+        let d = SubDelegate()
+        let firstSubscribed = expectation(description: "first subscribed")
+        d.onSub = {
+            firstSubscribed.fulfill()
+            d.onSub = { subscribed.fulfill() }
+        }
+        let sub = try client.newSubscription(channel: "ch", delegate: d, config: CentrifugeSubscriptionConfig())
+        sub.subscribe()
+        wait(for: [firstSubscribed], timeout: 5)
+        XCTAssertEqual(server.received().last(where: { $0.hasSubscribe })?.subscribe.recover, false)
+
+        server.unsubscribe("ch", unsubscribedStateInvalidated, "state invalidated")
+        wait(for: [subscribed], timeout: 5)
+
+        let req = try XCTUnwrap(server.received().last(where: { $0.hasSubscribe })?.subscribe)
+        XCTAssertTrue(req.recover, "resubscribe requests recovery (recover left true)")
+        XCTAssertEqual(req.epoch, "_", "resubscribe carries the unrecoverable sentinel epoch")
+        XCTAssertEqual(req.offset, 0, "resubscribe offset reset to 0")
+    }
+
+    func testDisconnect3014ClearsConnTokenRefreshesAndInvalidatesSubs() throws {
+        let counter = Counter()
+        var cfg = CentrifugeClientConfig()
+        cfg.token = "c0"
+        cfg.minReconnectDelay = 0.05
+        cfg.maxReconnectDelay = 0.2
+        cfg.tokenGetter = { _, completion in _ = counter.next(); completion(.success("c1")) }
+
+        let connected = expectation(description: "connected")
+        connected.expectedFulfillmentCount = 2  // initial + reconnect
+        connected.assertForOverFulfill = false
+        let cd = ClientDelegate()
+        cd.onConn = { connected.fulfill() }
+        let client = CentrifugeClient(endpoint: server.url, config: cfg, delegate: cd)
+        client.connect()
+        defer { client.disconnect() }
+
+        let subscribed = expectation(description: "subscribed")
+        subscribed.expectedFulfillmentCount = 2  // initial + resubscribe
+        subscribed.assertForOverFulfill = false
+        let sd = SubDelegate()
+        sd.onSub = { subscribed.fulfill() }
+        var subCfg = CentrifugeSubscriptionConfig()
+        subCfg.token = "sub-token-0"
+        let sub = try client.newSubscription(channel: "ch", delegate: sd, config: subCfg)
+        sub.subscribe()
+
+        let firstConnected = expectation(description: "first connected")
+        cd.onConn = {
+            firstConnected.fulfill()
+            cd.onConn = { connected.fulfill() }
+        }
+        wait(for: [firstConnected], timeout: 5)
+        XCTAssertEqual(lastConnectToken(), "c0")
+
+        server.disconnect(disconnectedStateInvalidated, "state invalidated")
+        wait(for: [connected, subscribed], timeout: 6)
+        XCTAssertGreaterThanOrEqual(counter.count(), 1, "3014 must trigger a fresh connection token fetch")
+        XCTAssertEqual(lastConnectToken(), "c1", "reconnect must use the freshly fetched token")
+        XCTAssertEqual(lastSubscribeToken(), "", "3014 must invalidate subscription token")
+    }
+}

--- a/Tests/SwiftCentrifugeTests/StateInvalidationTests.swift
+++ b/Tests/SwiftCentrifugeTests/StateInvalidationTests.swift
@@ -49,33 +49,33 @@ final class StateInvalidationTests: XCTestCase {
         server.received().last(where: { $0.hasConnect })?.connect.token
     }
 
+    private func lastSubscribe() -> Centrifugal_Centrifuge_Protocol_SubscribeRequest? {
+        server.received().last(where: { $0.hasSubscribe })?.subscribe
+    }
+
     func testUnsubscribe2502ClearsTokenAndResubscribes() throws {
         let client = CentrifugeClient(endpoint: server.url, config: CentrifugeClientConfig())
         client.connect()
         defer { client.disconnect() }
 
         let counter = Counter()
-        let subscribed = expectation(description: "subscribed")
-        subscribed.expectedFulfillmentCount = 2  // initial + resubscribe
-        subscribed.assertForOverFulfill = false
+        let firstSubscribed = expectation(description: "first subscribed")
+        let resubscribed = expectation(description: "resubscribed")
+        var subCount = 0
         let d = SubDelegate()
-        d.onSub = { subscribed.fulfill() }
+        d.onSub = {
+            subCount += 1
+            if subCount == 1 { firstSubscribed.fulfill() } else { resubscribed.fulfill() }
+        }
         var cfg = CentrifugeSubscriptionConfig()
         cfg.tokenGetter = { _, completion in completion(.success("t\(counter.next())")) }
         let sub = try client.newSubscription(channel: "ch", delegate: d, config: cfg)
         sub.subscribe()
-
-        // Wait for the first subscribe, assert it used the first fetched token.
-        let firstSubscribed = expectation(description: "first subscribed")
-        d.onSub = {
-            firstSubscribed.fulfill()
-            d.onSub = { subscribed.fulfill() }
-        }
         wait(for: [firstSubscribed], timeout: 5)
         XCTAssertEqual(lastSubscribeToken(), "t1")
 
         server.unsubscribe("ch", unsubscribedStateInvalidated, "state invalidated")
-        wait(for: [subscribed], timeout: 5)
+        wait(for: [resubscribed], timeout: 5)
         XCTAssertEqual(lastSubscribeToken(), "t2", "2502 must clear token so resubscribe fetches a fresh one")
         XCTAssertEqual(counter.count(), 2)
     }
@@ -95,24 +95,23 @@ final class StateInvalidationTests: XCTestCase {
         client.connect()
         defer { client.disconnect() }
 
-        let subscribed = expectation(description: "subscribed")
-        subscribed.expectedFulfillmentCount = 2
-        subscribed.assertForOverFulfill = false
-        let d = SubDelegate()
         let firstSubscribed = expectation(description: "first subscribed")
+        let resubscribed = expectation(description: "resubscribed")
+        var subCount = 0
+        let d = SubDelegate()
         d.onSub = {
-            firstSubscribed.fulfill()
-            d.onSub = { subscribed.fulfill() }
+            subCount += 1
+            if subCount == 1 { firstSubscribed.fulfill() } else { resubscribed.fulfill() }
         }
         let sub = try client.newSubscription(channel: "ch", delegate: d, config: CentrifugeSubscriptionConfig())
         sub.subscribe()
         wait(for: [firstSubscribed], timeout: 5)
-        XCTAssertEqual(server.received().last(where: { $0.hasSubscribe })?.subscribe.recover, false)
+        XCTAssertEqual(lastSubscribe()?.recover, false, "initial subscribe does not request recovery")
 
         server.unsubscribe("ch", unsubscribedStateInvalidated, "state invalidated")
-        wait(for: [subscribed], timeout: 5)
+        wait(for: [resubscribed], timeout: 5)
 
-        let req = try XCTUnwrap(server.received().last(where: { $0.hasSubscribe })?.subscribe)
+        let req = try XCTUnwrap(lastSubscribe())
         XCTAssertTrue(req.recover, "resubscribe requests recovery (recover left true)")
         XCTAssertEqual(req.epoch, "_", "resubscribe carries the unrecoverable sentinel epoch")
         XCTAssertEqual(req.offset, 0, "resubscribe offset reset to 0")
@@ -126,35 +125,35 @@ final class StateInvalidationTests: XCTestCase {
         cfg.maxReconnectDelay = 0.2
         cfg.tokenGetter = { _, completion in _ = counter.next(); completion(.success("c1")) }
 
-        let connected = expectation(description: "connected")
-        connected.expectedFulfillmentCount = 2  // initial + reconnect
-        connected.assertForOverFulfill = false
+        let firstConnected = expectation(description: "first connected")
+        let reconnected = expectation(description: "reconnected")
+        var connCount = 0
         let cd = ClientDelegate()
-        cd.onConn = { connected.fulfill() }
+        cd.onConn = {
+            connCount += 1
+            if connCount == 1 { firstConnected.fulfill() } else { reconnected.fulfill() }
+        }
         let client = CentrifugeClient(endpoint: server.url, config: cfg, delegate: cd)
         client.connect()
         defer { client.disconnect() }
 
-        let subscribed = expectation(description: "subscribed")
-        subscribed.expectedFulfillmentCount = 2  // initial + resubscribe
-        subscribed.assertForOverFulfill = false
+        let firstSubscribed = expectation(description: "first subscribed")
+        let resubscribed = expectation(description: "resubscribed")
+        var subCount = 0
         let sd = SubDelegate()
-        sd.onSub = { subscribed.fulfill() }
+        sd.onSub = {
+            subCount += 1
+            if subCount == 1 { firstSubscribed.fulfill() } else { resubscribed.fulfill() }
+        }
         var subCfg = CentrifugeSubscriptionConfig()
         subCfg.token = "sub-token-0"
         let sub = try client.newSubscription(channel: "ch", delegate: sd, config: subCfg)
         sub.subscribe()
-
-        let firstConnected = expectation(description: "first connected")
-        cd.onConn = {
-            firstConnected.fulfill()
-            cd.onConn = { connected.fulfill() }
-        }
-        wait(for: [firstConnected], timeout: 5)
+        wait(for: [firstConnected, firstSubscribed], timeout: 5)
         XCTAssertEqual(lastConnectToken(), "c0")
 
         server.disconnect(disconnectedStateInvalidated, "state invalidated")
-        wait(for: [connected, subscribed], timeout: 6)
+        wait(for: [reconnected, resubscribed], timeout: 8)
         XCTAssertGreaterThanOrEqual(counter.count(), 1, "3014 must trigger a fresh connection token fetch")
         XCTAssertEqual(lastConnectToken(), "c1", "reconnect must use the freshly fetched token")
         XCTAssertEqual(lastSubscribeToken(), "", "3014 must invalidate subscription token")


### PR DESCRIPTION
Handles server "state invalidated" signals so clients drop stale cached state and re-sync:

- **Unsubscribe code 2502** (per-subscription): clears the subscription token and cached state, then resubscribes.
- **Disconnect code 3014** (connection-wide): clears the connection token (forcing a fresh one via the token getter), invalidates every subscription, and reconnects. Funneled through `processDisconnect`, so it fires from **both** the Disconnect push and the WebSocket close frame.

`invalidateState` clears the token, fossil delta base and channel-compaction id, and resets the recovery position to a sentinel epoch (`"_"`, offset 0) the server can never match — leaving `recover` untouched. So a recoverable subscription resubscribes with `wasRecovering=true, recovered=false` (the app reloads via its existing recovery-failure path), while a non-recoverable one just resubscribes. The real epoch/offset are adopted from the subscribe reply.

Tests in `StateInvalidationTests.swift` (run with full Xcode toolchain): 2502 + 3014 token refresh/invalidation, and recoverable 2502 resubscribes unrecovered (`recover=true, epoch="_"`). The fake server gains close-with-code / disconnect-push helpers.
